### PR TITLE
docs(CHANGELOG): Add autogenerate workflow

### DIFF
--- a/.github/workflows/update-changelog-repo.yaml
+++ b/.github/workflows/update-changelog-repo.yaml
@@ -1,0 +1,36 @@
+name: Auto-generate CHANGELOG-repo
+on:
+    # release:
+    #   types: [created, edited]
+    schedule:
+        - cron: "0 14 * * *"
+    # push:
+    #     branches:
+    #         - main
+    workflow_dispatch:
+
+jobs:
+    generate-changelog:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: BobAnkh/auto-generate-changelog@master
+              with:
+                  REPO_NAME: "imAsparky/spinx-test"
+                  ACCESS_TOKEN: ${{secrets.CHANGELOG_UPDATE}}
+                  PATH: "/CHANGELOG.md"
+                  COMMIT_MESSAGE: "docs(CHANGELOG): update release notes:repo"
+                  TYPE: "build:Build,\
+                      ci:CI, \
+                      chore:Chore,\
+                      docs:Documentation,\
+                      feat:Feature,\
+                      fix:Bug Fixes,\
+                      perf:Performance Improvements,\
+                      refactor:Refactor,\
+                      revert:Revert, \
+                      style:Styling,\
+                      test:Tests,\
+                      WIP:In Progress"


### PR DESCRIPTION
This workflow will be used for testing semantic-version on protected branches.